### PR TITLE
refactor: :construction_worker: use Component Story Format

### DIFF
--- a/packages/ui/.eslintrc.js
+++ b/packages/ui/.eslintrc.js
@@ -7,5 +7,7 @@ module.exports = {
   ignorePatterns: ['dist/**/*'],
   rules: {
     'import/no-extraneous-dependencies': 'off',
+    'import/no-default-export': 'off',
+    'react/jsx-props-no-spreading': 'off',
   },
 };

--- a/packages/ui/.eslintrc.js
+++ b/packages/ui/.eslintrc.js
@@ -4,10 +4,8 @@ module.exports = {
     project: './tsconfig.json',
     tsconfigRootDir: __dirname,
   },
-  ignorePatterns: ['dist/**/*'],
+  ignorePatterns: ['dist/**/*', '*.stories.tsx'],
   rules: {
     'import/no-extraneous-dependencies': 'off',
-    'import/no-default-export': 'off',
-    'react/jsx-props-no-spreading': 'off',
   },
 };

--- a/packages/ui/.storybook/main.js
+++ b/packages/ui/.storybook/main.js
@@ -1,8 +1,9 @@
 module.exports = {
-  stories: ["../src/components/**/*.stories.(ts|tsx|js|jsx|mdx)"],
+  stories: ['../src/components/**/*.stories.(ts|tsx|js|jsx|mdx)'],
   addons: [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/preset-create-react-app",
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/preset-create-react-app',
+    '@storybook/addon-actions',
   ],
 };

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -6,7 +6,6 @@ const Template: Story<ButtonProps> = (args) => (
   <Button {...args}>Call to action</Button>
 );
 
-// 👇Each story then reuses that template
 export const Primary = Template.bind({});
 
 export const Secondary = Template.bind({});

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -1,39 +1,28 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { Button } from '.';
+import { Meta, Story } from '@storybook/react';
+import { Button, ButtonProps } from '.';
 
-storiesOf('Button', module)
-  .add('primary', () => <Button onClick={() => {}}>Call to Action</Button>)
-  .add('primary disabled', () => (
-    <Button onClick={() => {}} disabled>
-      Call to Action
-    </Button>
-  ))
-  .add('secondary', () => (
-    <Button onClick={() => {}} type='secondary'>
-      Call to Action
-    </Button>
-  ))
-  .add('onClick handler', () => (
-    // eslint-disable-next-line no-alert
-    <Button onClick={() => window && window.alert('Button Clicked!')}>
-      Click me!
-    </Button>
-  ))
-  .add('styled', () => (
-    <Button
-      onClick={() => {}}
-      style={{
-        backgroundColor: 'seagreen',
-        borderRadius: '25px',
-        minWidth: '180px',
-      }}
-    >
-      Call to Action
-    </Button>
-  ))
-  .add('submit', () => (
-    <Button onClick={() => {}} submit>
-      Call to Action
-    </Button>
-  ));
+const Template: Story<ButtonProps> = (args) => (
+  <Button {...args}>Call to action</Button>
+);
+
+// 👇Each story then reuses that template
+export const Primary = Template.bind({});
+
+export const Secondary = Template.bind({});
+Primary.args = { type: 'secondary' };
+
+export const Styled = Template.bind({});
+Styled.args = {
+  style: {
+    backgroundColor: 'seagreen',
+    borderRadius: '25px',
+    minWidth: '180px',
+  },
+};
+
+export default {
+  title: 'Components/Button',
+  component: Button,
+  argTypes: { onClick: { action: 'clicked here' } },
+} as Meta;


### PR DESCRIPTION
hi @paschalidi,
I migrated the code to use CSF, I think it looks better and it is easier to maintain the components now. It is also easier to see them on storybook, check how on can now change different properties directly in each view. 

1. I added two rules to the `.eslintrcjs` in the `ui`, I know we want to avoid it, but in this case I think it makes sense. Also, It is required to use export defaults to use CRF. In the end we are just modifying the rules for `ui` so it should be fine, I think. Let me know if I am missing something.