### PR TITLE
chore: make `typescript` a devDependency

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,7 +21,6 @@
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.1",
     "styled-components": "^5.2.1",
-    "typescript": "^4.1.3",
     "web-vitals": "^0.2.4"
   },
   "devDependencies": {
@@ -31,7 +30,8 @@
     "@storybook/node-logger": "^6.1.14",
     "@storybook/preset-create-react-app": "^3.1.5",
     "@storybook/react": "^6.1.14",
-    "eslint-config-small-ads": "^0.1.0"
+    "eslint-config-small-ads": "^0.1.0",
+    "typescript": "^4.2.2"
   },
   "scripts": {
     "start": "start-storybook -p 6006 -s public",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,7 +8,6 @@
   ],
   "private": true,
   "dependencies": {
-    "@storybook/addon-docs": "^6.1.14",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.3",
     "@testing-library/user-event": "^12.6.0",
@@ -16,7 +15,6 @@
     "@types/node": "^12.19.14",
     "@types/react": "^16.14.2",
     "@types/react-dom": "^16.9.10",
-    "@types/styled-components": "^5.1.7",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.1",
@@ -30,6 +28,7 @@
     "@storybook/node-logger": "^6.1.14",
     "@storybook/preset-create-react-app": "^3.1.5",
     "@storybook/react": "^6.1.14",
+    "@types/styled-components": "^5.1.7",
     "eslint-config-small-ads": "^0.1.0",
     "typescript": "^4.2.2"
   },

--- a/src/webapp/package.json
+++ b/src/webapp/package.json
@@ -22,11 +22,11 @@
     "react-redux": "^7.2.2",
     "react-scripts": "4.0.1",
     "styled-components": "^5.2.1",
-    "typescript": "^4.1.3",
     "web-vitals": "^0.2.4"
   },
   "devDependencies": {
-    "eslint-config-small-ads": "^0.1.0"
+    "eslint-config-small-ads": "^0.1.0",
+    "typescript": "^4.2.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/webapp/package.json
+++ b/src/webapp/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@firebase/auth-types": "^0.10.2",
-    "@firebase/firestore-types": "^2.1.0",
     "@reduxjs/toolkit": "^1.5.0",
     "@small-ads/ui": "^0.1.0",
     "@testing-library/jest-dom": "^5.11.9",
@@ -15,7 +14,6 @@
     "@types/react": "^16.14.2",
     "@types/react-dom": "^16.9.10",
     "@types/react-redux": "^7.1.16",
-    "@types/styled-components": "^5.1.7",
     "firebase": "^8.2.6",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -25,6 +23,7 @@
     "web-vitals": "^0.2.4"
   },
   "devDependencies": {
+    "@types/styled-components": "^5.1.7",
     "eslint-config-small-ads": "^0.1.0",
     "typescript": "^4.2.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1534,7 +1534,7 @@
     faye-websocket "0.11.3"
     tslib "^1.11.1"
 
-"@firebase/firestore-types@2.1.0", "@firebase/firestore-types@^2.1.0":
+"@firebase/firestore-types@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-2.1.0.tgz#ad406c6fd7f0eae7ea52979f712daa0166aef665"
   integrity sha512-jietErBWihMvJkqqEquQy5GgoEwzHnMXXC/TsVoe9FPysXm1/AeJS12taS7ZYvenAtyvL/AEJyKrRKRh4adcJQ==
@@ -3009,7 +3009,7 @@
     core-js "^3.0.1"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-docs@6.1.17", "@storybook/addon-docs@^6.1.14":
+"@storybook/addon-docs@6.1.17":
   version "6.1.17"
   resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-6.1.17.tgz#bb9d12d6d8da399e5c69c3552ce54eca17fe770d"
   integrity sha512-Y+IOR9tc1l4uPk+eZkhUAxjc6Xo82Jf0ERKWOKBdy4bDm34pRdpn4zAfMYuv9D8M0F/O1kUGhMlaHgE9a7YvNw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -16745,6 +16745,11 @@ typescript@^4.1.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.4.tgz#f058636e2f4f83f94ddaae07b20fd5e14598432f"
   integrity sha512-+Uru0t8qIRgjuCpiSPpfGuhHecMllk5Zsazj5LZvVsEStEjmIRRBZe+jHjGQvsgS7M1wONy2PQXd67EMyV6acg==
 
+typescript@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
+  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
+
 uglify-js@^3.1.4:
   version "3.12.6"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.6.tgz#f884584fcc42e10bca70db5cb32e8625c2c42535"


### PR DESCRIPTION
hi @paschalidi,
Even though the issue says

> Make typescript devDependency in all the repos we have

I didn't do it on @small-ads because I thought there we do need as a dependency. Am I wrong?
Sorry I ask, I am trying to get see what parts of how the process works I am missing.