### PR TITLE
chore: builds the ui before starting the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "lint": "lerna run lint --parallel --stream",
-    "start:webapp": "lerna run --scope @small-ads/webapp start --stream",
+    "start:webapp": "yarn build:package && lerna run --scope @small-ads/webapp start --stream",
     "start:storybook": "lerna run --scope @small-ads/ui start --stream",
     "start": "lerna run start --parallel --stream",
     "typecheck": "lerna run typecheck --parallel --stream",


### PR DESCRIPTION
hey adding this bit on the start:webapp script. Find it useful that the ui package is build for me when I start the app. 