### PR TITLE
refactor: improve icon positioning

### DIFF
--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -8,7 +8,7 @@ type Sizes = ['xs', 'sm', 'md', 'lg'];
 const sizes: Sizes = ['xs', 'sm', 'md', 'lg'];
 
 const ButtonsSeparator = styled.div`
-  margin-bottom: 15px;
+  margin-bottom: 16px;
 `;
 
 const Template: Story<ButtonProps> = (args) => {

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -2,43 +2,40 @@ import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import { Button, ButtonProps } from '.';
 import { Facebook } from '@styled-icons/boxicons-logos/Facebook';
+import styled from 'styled-components';
 
-const Template: Story<ButtonProps> = (args) => (
-  <Button {...args}>Call to action </Button>
-);
+type Sizes = ['xs', 'sm', 'md', 'lg'];
+const sizes: Sizes = ['xs', 'sm', 'md', 'lg'];
+
+const ButtonsSeparator = styled.div`
+  margin-bottom: 15px;
+`;
+
+const Template: Story<ButtonProps> = (args) => {
+  return (
+    <>
+      {sizes.map((size) => (
+        <ButtonsSeparator key={size}>
+          <Button {...args} size={size}>
+            Call to action
+          </Button>
+        </ButtonsSeparator>
+      ))}
+    </>
+  );
+};
 
 export const Primary = Template.bind({});
 
 export const Secondary = Template.bind({});
 Secondary.args = { type: 'secondary' };
 
-export const XsPrimary = Template.bind({});
-XsPrimary.args = { size: 'xs' };
-
-export const SmPrimary = Template.bind({});
-SmPrimary.args = { size: 'sm' };
-
-export const LgPrimary = Template.bind({});
-LgPrimary.args = { size: 'lg' };
-
-export const XsSecondary = Template.bind({});
-XsSecondary.args = { type: 'secondary', size: 'xs' };
-
-export const SmSecondary = Template.bind({});
-SmSecondary.args = { type: 'secondary', size: 'sm' };
-
-export const LgSecondary = Template.bind({});
-LgSecondary.args = { type: 'secondary', size: 'lg' };
+export const Disabled = Template.bind({});
+Disabled.args = { disabled: true };
 
 export const WithIcon = Template.bind({});
 WithIcon.args = {
-  icon: <Facebook size={20} />,
-  style: {
-    width: '220px',
-    backgroundColor: '#1877f2',
-    border: '1px solid #1877f2',
-    color: 'white',
-  },
+  icon: <Facebook />,
 };
 
 export const FullWidth = Template.bind({});
@@ -46,11 +43,10 @@ FullWidth.args = { fullWidth: true };
 
 export const Styled = Template.bind({});
 Styled.args = {
-  icon: <Facebook size={20} />,
+  icon: <Facebook />,
   style: {
     backgroundColor: 'seagreen',
     borderRadius: '25px',
-    minWidth: '180px',
   },
 };
 

--- a/packages/ui/src/components/Button/button.style.ts
+++ b/packages/ui/src/components/Button/button.style.ts
@@ -94,12 +94,10 @@ export const ButtonStyles = styled.div<CustomProps>`
   .md,
   .lg {
     span {
-      position: absolute;
       display: flex;
       -webkit-box-align: center;
       align-items: center;
-      inset: 0px auto 0px 22px;
-      z-index: 1;
+      margin-inline-end: 3px;
     }
   }
 `;

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import { ButtonStyles } from './button.style';
 

--- a/src/webapp/src/auth/AuthenticationOptions.tsx
+++ b/src/webapp/src/auth/AuthenticationOptions.tsx
@@ -43,6 +43,10 @@ const FacebookButton = styled(Button)`
     background-color: #1877f2;
     border: 1px solid #1877f2;
     color: white;
+    span {
+      position: absolute;
+      inset: 0px auto 0px 22px;
+    }
     &:hover {
       background-color: #166fe5;
       border: 1px solid #166fe5;


### PR DESCRIPTION
hi @paschalidi,

1. When I was showing different icons sizes in each story I realized this is a better way of handling our icon. So now instead of having the icon always completely to the left, we will have it next to the button-text (how Chakra does it). Then we will use `position: absolute` for the specific cases if we want to do something similar to what Vercel does for the login buttons.
   
  You were right all along with changing that! What a surprise!!! :D Who am I to doubt you?! :D

2. I add all the sizes of a button for each story. I chose to display the button one top of each other, instead of one next to each other, but we can change it of course. Would you like me to add some more story?
