### PR TITLE
suggestion: avoid disabling eslint rules y having a file for hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "devDependencies": {
     "lerna": "^3.22.1",
     "prettier": "^2.2.1"
+  },
+  "prettier": {
+    "singleQuote": true
   }
 }

--- a/src/webapp/src/auth/Auth.tsx
+++ b/src/webapp/src/auth/Auth.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import { useDispatch, useSelector } from 'react-redux';
 import { AuthStatuses } from './types';
-import { RootState } from '../reducers';
 import { signInUser, signOutUser } from './asyncAuthActions';
+import { selectUser } from './userSlice';
 
 const Loader = styled.div`
   border: 12px solid #f3f3f3;
@@ -26,7 +26,7 @@ const Loader = styled.div`
 export const Auth = () => {
   const dispatch = useDispatch();
   const { authStatus, uid, displayName, email, error } = useSelector(
-    (state: RootState) => state.user
+    selectUser
   );
 
   const handleSignIn = () => {

--- a/src/webapp/src/auth/userSlice.ts
+++ b/src/webapp/src/auth/userSlice.ts
@@ -1,6 +1,8 @@
+/* eslint-disable import/no-cycle */
 import { createSlice } from '@reduxjs/toolkit';
 import { AuthStatuses, Login } from './types';
 import { signInUser, signOutUser } from './asyncAuthActions';
+import { RootState } from '../reducers';
 
 const initialState: Login = {
   uid: undefined,
@@ -44,3 +46,4 @@ export const userSlice = createSlice({
 });
 
 export const userReducer = userSlice.reducer;
+export const selectUser = (state: RootState) => state.user;

--- a/src/webapp/src/reducers.ts
+++ b/src/webapp/src/reducers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-cycle */
 import { combineReducers } from '@reduxjs/toolkit';
 import { userReducer } from './auth/userSlice';
 import { charactersReducer } from './characters/charactersSlice';


### PR DESCRIPTION
this is related to the PR https://github.com/small-ads/core/pull/61

I am suggesting this approach which lets us avoid having to disable eslint rules by having the hooks in its own folder. 
Basically when later we have more complicated hooks you will find that we will start reusing hooks around the app. This way we can already have them prepared to be shared around.

Also redux is a great tool but suggestions always go both ways 
<img src="https://user-images.githubusercontent.com/4181674/110393566-ab0f7780-8062-11eb-98de-9a1fc168d406.png" width="60%">
We dont have to go this way as this is really a suggestion. However I am not a huge fun of introducing eslint breaks. There is always a workaround it. 

Another way we could do the same is instead of having the `hooks.ts` file we could have a `selector.ts` file, like so.
```
// selector.ts
export const selectUser = (state: RootState) => state.user;
```